### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build-web:
     runs-on: ubuntu-latest
@@ -27,6 +30,8 @@ jobs:
 
   build-desktop:
     needs: build-web
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/ObscuritySecurity/CrytoTool/security/code-scanning/4](https://github.com/ObscuritySecurity/CrytoTool/security/code-scanning/4)

In general, the fix is to add explicit `permissions:` to the workflow (at the top level and/or per job) so that the `GITHUB_TOKEN` is restricted to the minimal scopes required. For simple build-and-artifact workflows, `contents: read` is usually sufficient. In this workflow, only the `build-desktop` job uses `GITHUB_TOKEN` via `tauri-apps/tauri-action@v0` to create or update releases, which requires some write permission to repository contents or to releases. A good balance is: set a restrictive default at the workflow level (`contents: read`) and then override permissions for `build-desktop` to grant just enough write access to publish release artifacts.

Concretely:
- Add a root-level `permissions:` section near the top of `.github/workflows/build.yml` (e.g., after the `on:` block) with `contents: read`. This will apply to all jobs by default.
- Add a `permissions:` block under `build-desktop:` that allows writing to contents (or, if you prefer finer granularity and your GitHub plan supports it, to specific release-related permissions; for simplicity and compatibility, we’ll use `contents: write` here).
- The `build-web` and `build-android` jobs will inherit `contents: read` and thus have no unnecessary write access.

No additional imports or dependencies are required; this is purely a YAML configuration change within `.github/workflows/build.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
