### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Build Universal Linux App
 on: [push]
 
+permissions:
+  contents: write
+  packages: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04 # Folosește o versiune mai veche pentru compatibilitate glibc mai largă


### PR DESCRIPTION
Potential fix for [https://github.com/ObscuritySecurity/CrytoTool/security/code-scanning/5](https://github.com/ObscuritySecurity/CrytoTool/security/code-scanning/5)

Add an explicit `permissions` block in `.github/workflows/release.yml` at the workflow root (right after `on:`), so all jobs inherit it unless overridden.  
For this workflow, the best minimal functional set is:

- `contents: write` (required to create/update GitHub releases/tags via `tauri-action`)
- `packages: read` (safe/common read scope; optional but aligned with GitHub guidance for explicit defaults)

This preserves existing behavior while constraining token access compared to unspecified defaults. No imports, methods, or external definitions are needed—just YAML key insertion in the shown file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
