### PR TITLE
fix: align tauri workflow tagName/releaseName with actual git tag (sa…

### DIFF
--- a/.github/workflows/tauri-linux.yml
+++ b/.github/workflows/tauri-linux.yml
@@ -42,8 +42,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: app-v__VERSION__
-          releaseName: 'CrytoTool v__VERSION__'
-          releaseBody: 'CrytoTool Vault - Secure Password Manager'
+          tagName: ${{ github.ref_name }}
+          releaseName: 'CrytoTool ${{ github.ref_name }}'
+          releaseBody: 'CrytoTool ${{ github.ref_name }}'
           releaseDraft: true
           prerelease: false

--- a/.github/workflows/tauri-macos.yml
+++ b/.github/workflows/tauri-macos.yml
@@ -48,9 +48,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: app-v__VERSION__
-          releaseName: 'CrytoTool v__VERSION__'
-          releaseBody: 'CrytoTool Vault - Secure Password Manager'
+          tagName: ${{ github.ref_name }}
+          releaseName: 'CrytoTool ${{ github.ref_name }}'
+          releaseBody: 'CrytoTool ${{ github.ref_name }}'
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}

--- a/.github/workflows/tauri-windows.yml
+++ b/.github/workflows/tauri-windows.yml
@@ -37,8 +37,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: app-v__VERSION__
-          releaseName: 'CrytoTool v__VERSION__'
-          releaseBody: 'CrytoTool Vault - Secure Password Manager'
+          tagName: ${{ github.ref_name }}
+          releaseName: 'CrytoTool ${{ github.ref_name }}'
+          releaseBody: 'CrytoTool ${{ github.ref_name }}'
           releaseDraft: true
           prerelease: false


### PR DESCRIPTION
…me release for all workflows)

## Summary

<!-- What does this PR do? Why is it needed? -->

**Issue:** <!-- Closes #..., Fixes #... -->

**Type:** Bug fix / New feature / Security fix / Refactor / Docs / CI / Breaking change

**Platform:** Desktop / Mobile / Web / All

---

## Changes

<!-- List key changes: added, modified, fixed, removed. Be concise. -->

-

---

## Protocol-3305 alignment

CrytoTool follows [Protocol-3305](https://github.com/ObscuritySecurity/protocol-3305).  
🟢 = compliant, 🟡 = affected (explain), 🔴 = violation (blocking).

| Art. | Principle | Status | Notes |
| ---- | --------- | ------ | ----- |
| 0 | Ethical Monetization | 🟢 🟡 🔴 | |
| 1 | Privacy by Design | 🟢 🟡 🔴 | |
| 2 | Security by Default | 🟢 🟡 🔴 | |
| 3 | Zero Trust | 🟢 🟡 🔴 | |
| 4 | Zero Knowledge | 🟢 🟡 🔴 | |
| 5 | Zero Personal Data Collection | 🟢 🟡 🔴 | |
| 6 | Zero Activity Logs | 🟢 🟡 🔴 | |
| 7 | Open Source | 🟢 🟡 🔴 | |
| 8 | Zero Non-Essential Permissions | 🟢 🟡 🔴 | |

---

## Checklist

- [ ] Tested on target platform(s)
- [ ] `npx tsc --noEmit` passes
- [ ] No telemetry / tracking added
- [ ] Docs updated (if applicable)
