### PR TITLE
docs: add vulnerability reporting link to audit status section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ CrytoTool is open source so anyone can audit the code, report issues, suggest im
 
 If you find something, [report it](https://github.com/ObscuritySecurity/CrytoTool/issues). If you can fix something, [open a pull request](https://github.com/ObscuritySecurity/CrytoTool/blob/main/docs/CONTRIBUTING.md). Security is not a product — it's a process, and we build it together.
 
-**Audit Status:** The CrytoTool codebase has not yet undergone a professional third-party security audit. Professional audits are expensive, and as a community-driven project we don't have the budget for one yet. We hope to fund a full audit in the future. Until then, the code is open for anyone to review — and we encourage you to do so.
+**Audit Status:** The CrytoTool codebase has not yet undergone a professional third-party security audit. Professional audits are expensive, and as a community-driven project we don't have the budget for one yet. We hope to fund a full audit in the future. Until then, the code is open for anyone to review — and we encourage you to do so. If you find a vulnerability, please [report it privately](https://github.com/ObscuritySecurity/CrytoTool/security/advisories/new).
 
 ### Architecture Overview
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Why is it needed? -->

**Issue:** <!-- Closes #..., Fixes #... -->

**Type:** Bug fix / New feature / Security fix / Refactor / Docs / CI / Breaking change
Docs

**Platform:** Desktop / Mobile / Web / All

---

## Changes
docs: add vulnerability reporting link to audit status section

<!-- List key changes: added, modified, fixed, 
removed. Be concise. -->
Add

-

---

## Protocol-3305 alignment

CrytoTool follows [Protocol-3305](https://github.com/ObscuritySecurity/protocol-3305).  
🟢 = compliant, 🟡 = affected (explain), 🔴 = violation (blocking).

| Art. | Principle | Status | Notes |
| ---- | --------- | ------ | ----- |
| 0 | Ethical Monetization | 🟢  | |
| 1 | Privacy by Design | 🟢  | |
| 2 | Security by Default | 🟢  | |
| 3 | Zero Trust | 🟢  | |
| 4 | Zero Knowledge | 🟢  | |
| 5 | Zero Personal Data Collection | 🟢  | |
| 6 | Zero Activity Logs | 🟢  | |
| 7 | Open Source | 🟢  | |
| 8 | Zero Non-Essential Permissions | 🟢  | |

---

## Checklist

- [✓ ] Tested on target platform(s)
- [ ✓] `npx tsc --noEmit` passes
- [ ✓] No telemetry / tracking added
- [ ✓] Docs updated (if applicable)
