### PR TITLE
fix: manual accent priority over theme accent

### DIFF
--- a/.opencode-pr-test.md
+++ b/.opencode-pr-test.md
@@ -1,0 +1,3 @@
+# opencode PR test
+
+Test commit for pull request flow verification.

--- a/.opencode-pr-test.md
+++ b/.opencode-pr-test.md
@@ -1,3 +1,0 @@
-# opencode PR test
-
-Test commit for pull request flow verification.

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -137,7 +137,27 @@ export const Dashboard: React.FC<DashboardProps> = ({
     }
     return mode;
   };
-  const [accentColor, setAccentColor] = useState(localStorage.getItem('theme_accent') || '#39ff14');
+  const [accentColor, setAccentColor] = useState(() => {
+    return localStorage.getItem('app_accent_manual') || localStorage.getItem('theme_accent') || '#39ff14';
+  });
+  const setManualAccent = (color: string) => {
+    setAccentColor(color);
+    localStorage.setItem('app_accent_manual', color);
+  };
+  const clearManualAccent = () => {
+    localStorage.removeItem('app_accent_manual');
+    const config = localStorage.getItem('app_theme_config');
+    if (config) {
+      try {
+        const c = JSON.parse(config);
+        if (c['--accent-color']) {
+          setAccentColor(c['--accent-color']);
+          return;
+        }
+      } catch {}
+    }
+    setAccentColor('#39ff14');
+  };
   const [activeThemeCategory, setActiveThemeCategory] = useState<ThemeCategory>('Neon');
   const [currentFolderId, setCurrentFolderId] = useState<string | null>(null);
   const [activeItem, setActiveItem] = useState<FileSystemItem | null>(null); 
@@ -206,7 +226,10 @@ export const Dashboard: React.FC<DashboardProps> = ({
             root.style.setProperty(key, value);
           }
         });
-        if (config['--accent-color']) {
+        const manualAccent = localStorage.getItem('app_accent_manual');
+        if (manualAccent) {
+          setAccentColor(manualAccent);
+        } else if (config['--accent-color']) {
           setAccentColor(config['--accent-color']);
         }
       } catch (e) {
@@ -442,8 +465,6 @@ export const Dashboard: React.FC<DashboardProps> = ({
     root.style.setProperty('--border-color', theme.border);
     root.style.setProperty('--text-main', theme.textMain);
     root.style.setProperty('--text-muted', theme.textMuted);
-    setAccentColor(theme.accent);
-    localStorage.setItem('theme_accent', theme.accent);
     localStorage.setItem('app_theme_config', JSON.stringify({
         '--bg-main': theme.bgMain, '--bg-card': theme.bgCard, '--bg-surface': theme.bgSurface,
         '--border-color': theme.border, '--text-main': theme.textMain, '--text-muted': theme.textMuted,
@@ -451,6 +472,11 @@ export const Dashboard: React.FC<DashboardProps> = ({
     }));
     // Remove app_theme_mode so it doesn't interfere on reload
     localStorage.removeItem('app_theme_mode');
+    // Only set accent to theme's color if no manual override
+    const manualAccent = localStorage.getItem('app_accent_manual');
+    if (!manualAccent) {
+      setAccentColor(theme.accent);
+    }
   };
 
   const items = useMemo(() => allItems.filter(i => !i.isTrashed), [allItems]);
@@ -1036,7 +1062,8 @@ export const Dashboard: React.FC<DashboardProps> = ({
               appTheme={appTheme} 
               setAppTheme={setAppTheme} 
               accentColor={accentColor} 
-              setAccentColor={setAccentColor} 
+              setManualAccent={setManualAccent} 
+              clearManualAccent={clearManualAccent} 
               autoBlurSettings={autoBlurSettings} 
               autoLockSettings={autoLockSettings} 
               progressiveLockSettings={progressiveLockSettings}

--- a/components/views/SettingsView.tsx
+++ b/components/views/SettingsView.tsx
@@ -21,7 +21,8 @@ interface SettingsViewProps {
   appTheme: AppTheme;
   setAppTheme: (t: AppTheme) => void;
   accentColor: string;
-  setAccentColor: (c: string) => void;
+  setManualAccent: (c: string) => void;
+  clearManualAccent: () => void;
   applyFullTheme: (theme: ThemeConfig) => void;
   autoBlurSettings: { value: number; setValue: (val: number) => void; };
   autoLockSettings: { value: number; setValue: (val: number) => void; };
@@ -193,7 +194,18 @@ export const SettingsView: React.FC<SettingsViewProps> = (props) => {
                     <PaintBucket size={14} className="text-muted" />
                     <span className="text-[10px] font-black uppercase tracking-widest text-muted">{t('accentManual')}</span>
                 </div>
-                <CustomColorPicker color={props.accentColor} onChange={props.setAccentColor} />
+                <div className="flex items-center gap-2">
+                  <div className="flex-1">
+                    <CustomColorPicker color={props.accentColor} onChange={props.setManualAccent} />
+                  </div>
+                  <button
+                    onClick={props.clearManualAccent}
+                    className="px-4 py-3 rounded-xl border border-border text-[10px] font-black uppercase tracking-widest text-muted hover:text-white hover:border-red-500/50 hover:bg-red-500/10 transition-all shrink-0"
+                    title="Resetează la accentul temei"
+                  >
+                    {t('reset')}
+                  </button>
+                </div>
                 </div>
             </section>
 
@@ -709,7 +721,7 @@ export const ThemesGalleryView: React.FC<{
       <div className="flex-1 overflow-y-auto px-5 py-6">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {displayThemes.map(theme => {
-                  const isActive = selectedThemeId === theme.id || (selectedThemeId === null && localStorage.getItem('theme_accent') === theme.accent && 
+                  const isActive = selectedThemeId === theme.id || (selectedThemeId === null && 
                                    getComputedStyle(document.documentElement).getPropertyValue('--bg-main').trim() === theme.bgMain);
                   const isLight = theme.textMain === '#09090b';
                   

--- a/index.html
+++ b/index.html
@@ -14,6 +14,11 @@
       // Load saved theme immediately to prevent flash
       (function() {
         const savedTheme = JSON.parse(localStorage.getItem('app_theme_config') || '{}');
+        // Manual accent override wins over theme config
+        const manualAccent = localStorage.getItem('app_accent_manual');
+        if (manualAccent) {
+          savedTheme['--accent-color'] = manualAccent;
+        }
         const savedFont = 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
         
         const root = document.documentElement;


### PR DESCRIPTION
## Bug
Manual accent was lost on theme reset/reload.

## Fix
- **app_accent_manual** — new localStorage key with highest priority
- **applyFullTheme** — no longer overwrites accent if manual is set
- **index.html** — prefers manual accent over theme config
- **Settings** — Reset button clears manual accent (falls back to theme)
- **ThemesGalleryView** — active detection no longer depends on accent match