### PR TITLE
Fix gallery photo display + accent reset bug

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -346,6 +346,16 @@ export const Dashboard: React.FC<DashboardProps> = ({
     const b = parseInt(accentColor.slice(5, 7), 16);
     root.style.setProperty('--accent-rgb', `${r}, ${g}, ${b}`);
     localStorage.setItem('theme_accent', accentColor);
+    const savedConfig = localStorage.getItem('app_theme_config');
+    if (savedConfig) {
+      try {
+        const config = JSON.parse(savedConfig);
+        config['--accent-color'] = accentColor;
+        localStorage.setItem('app_theme_config', JSON.stringify(config));
+      } catch (e) {
+        // ignore parse errors
+      }
+    }
   }, [accentColor]);
 
   useEffect(() => {
@@ -476,6 +486,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
     const manualAccent = localStorage.getItem('app_accent_manual');
     if (!manualAccent) {
       setAccentColor(theme.accent);
+      localStorage.setItem('theme_accent', theme.accent);
     }
   };
 

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -299,24 +299,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
 
   const decryptOnDemand = async (item: FileSystemItem): Promise<string | null> => {
     if (decryptedUrls[item.id]) return decryptedUrls[item.id];
-    if (!item.rawBlob || !item.isEncrypted || !item.iv) {
-      if (item.rawBlob && !item.isEncrypted) {
-        const blob = item.rawBlob instanceof Blob ? item.rawBlob : new Blob([item.rawBlob]);
-        const ext = item.name.split('.').pop()?.toLowerCase() || '';
-        const mimeType = ext === 'gif' ? 'image/gif' :
-                         ext === 'png' ? 'image/png' :
-                         ext === 'webp' ? 'image/webp' :
-                         item.category === 'image' ? 'image/jpeg' :
-                         ext === 'mp3' ? 'audio/mpeg' :
-                         item.category === 'audio' ? 'audio/mpeg' :
-                         ext === 'webm' ? 'video/webm' :
-                         item.category === 'video' ? 'video/mp4' : 'application/octet-stream';
-        const url = URL.createObjectURL(blob);
-        setDecryptedUrls(prev => ({ ...prev, [item.id]: url }));
-        return url;
-      }
-      return item.url || null;
-    }
+    if (!item.rawBlob || !item.isEncrypted || !item.iv) return item.url || null;
 
     try {
       if (item.salt) {
@@ -331,14 +314,25 @@ export const Dashboard: React.FC<DashboardProps> = ({
           const iv = cryptoService.base64ToArrayBuffer(item.iv);
           const decryptedData = await cryptoService.decrypt(encryptedData, iv);
           
-          const ext = item.name.split('.').pop()?.toLowerCase() || '';
+          const sourceName = (item as any).decryptedName || item.name;
+          const ext = sourceName.split('.').pop()?.toLowerCase() || '';
           const mimeType = ext === 'gif' ? 'image/gif' :
                            ext === 'png' ? 'image/png' :
                            ext === 'webp' ? 'image/webp' :
+                           ext === 'jpg' || ext === 'jpeg' || ext === 'jfif' ? 'image/jpeg' :
+                           ext === 'svg' ? 'image/svg+xml' :
+                           ext === 'avif' ? 'image/avif' :
+                           ext === 'bmp' ? 'image/bmp' :
+                           ext === 'ico' ? 'image/x-icon' :
                            item.category === 'image' ? 'image/jpeg' :
                            ext === 'mp3' ? 'audio/mpeg' :
+                           ext === 'wav' ? 'audio/wav' :
+                           ext === 'ogg' ? 'audio/ogg' :
+                           ext === 'flac' ? 'audio/flac' :
                            item.category === 'audio' ? 'audio/mpeg' :
+                           ext === 'mp4' ? 'video/mp4' :
                            ext === 'webm' ? 'video/webm' :
+                           ext === 'mkv' ? 'video/x-matroska' :
                            item.category === 'video' ? 'video/mp4' : 'application/octet-stream';
 
            const arrayBuffer = decryptedData.buffer.slice(decryptedData.byteOffset, decryptedData.byteOffset + decryptedData.byteLength) as ArrayBuffer;
@@ -479,18 +473,6 @@ export const Dashboard: React.FC<DashboardProps> = ({
       }));
       
       setAllItems([...systemItems, ...loadedItems]);
-
-      // Pre-create blob URLs for non-encrypted imported files so they display immediately in the gallery
-      const initialUrls: Record<string, string> = {};
-      loadedItems.forEach(item => {
-        if (item.rawBlob && !item.isEncrypted && !item.url && !decryptedUrls[item.id]) {
-          const blob = item.rawBlob instanceof Blob ? item.rawBlob : new Blob([item.rawBlob]);
-          initialUrls[item.id] = URL.createObjectURL(blob);
-        }
-      });
-      if (Object.keys(initialUrls).length > 0) {
-        setDecryptedUrls(prev => ({ ...prev, ...initialUrls }));
-      }
     } catch (e) {
       console.error("Failed to load items from DB", e);
     }

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -299,7 +299,24 @@ export const Dashboard: React.FC<DashboardProps> = ({
 
   const decryptOnDemand = async (item: FileSystemItem): Promise<string | null> => {
     if (decryptedUrls[item.id]) return decryptedUrls[item.id];
-    if (!item.rawBlob || !item.isEncrypted || !item.iv) return item.url || null;
+    if (!item.rawBlob || !item.isEncrypted || !item.iv) {
+      if (item.rawBlob && !item.isEncrypted) {
+        const blob = item.rawBlob instanceof Blob ? item.rawBlob : new Blob([item.rawBlob]);
+        const ext = item.name.split('.').pop()?.toLowerCase() || '';
+        const mimeType = ext === 'gif' ? 'image/gif' :
+                         ext === 'png' ? 'image/png' :
+                         ext === 'webp' ? 'image/webp' :
+                         item.category === 'image' ? 'image/jpeg' :
+                         ext === 'mp3' ? 'audio/mpeg' :
+                         item.category === 'audio' ? 'audio/mpeg' :
+                         ext === 'webm' ? 'video/webm' :
+                         item.category === 'video' ? 'video/mp4' : 'application/octet-stream';
+        const url = URL.createObjectURL(blob);
+        setDecryptedUrls(prev => ({ ...prev, [item.id]: url }));
+        return url;
+      }
+      return item.url || null;
+    }
 
     try {
       if (item.salt) {
@@ -462,6 +479,18 @@ export const Dashboard: React.FC<DashboardProps> = ({
       }));
       
       setAllItems([...systemItems, ...loadedItems]);
+
+      // Pre-create blob URLs for non-encrypted imported files so they display immediately in the gallery
+      const initialUrls: Record<string, string> = {};
+      loadedItems.forEach(item => {
+        if (item.rawBlob && !item.isEncrypted && !item.url && !decryptedUrls[item.id]) {
+          const blob = item.rawBlob instanceof Blob ? item.rawBlob : new Blob([item.rawBlob]);
+          initialUrls[item.id] = URL.createObjectURL(blob);
+        }
+      });
+      if (Object.keys(initialUrls).length > 0) {
+        setDecryptedUrls(prev => ({ ...prev, ...initialUrls }));
+      }
     } catch (e) {
       console.error("Failed to load items from DB", e);
     }

--- a/components/views/GalleryView.tsx
+++ b/components/views/GalleryView.tsx
@@ -22,6 +22,23 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ items, onNavigate, the
   const { t } = useI18n();
   const [subTab, setSubTab] = useState<GallerySubTab>('all');
   const [lightboxItem, setLightboxItem] = useState<FileSystemItem | null>(null);
+  const [decryptingIds, setDecryptingIds] = useState<Set<string>>(new Set());
+
+  // Auto-decrypt items that were auto-encrypted during import (no salt, no password needed)
+  useEffect(() => {
+    const toDecrypt = items.filter(
+      item => item.isEncrypted && !item.salt && item.rawBlob && !decryptedUrls[item.id]
+    );
+    if (toDecrypt.length === 0) return;
+    setDecryptingIds(prev => new Set([...prev, ...toDecrypt.map(i => i.id)]));
+    Promise.all(toDecrypt.map(item => onDecrypt(item))).then(() => {
+      setDecryptingIds(prev => {
+        const next = new Set(prev);
+        toDecrypt.forEach(i => next.delete(i.id));
+        return next;
+      });
+    });
+  }, [items, onDecrypt]);
 
   const filteredItems = useMemo(() => {
     return items.filter(item => {
@@ -36,12 +53,11 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ items, onNavigate, the
     });
   }, [items, subTab]);
 
-  const handleItemClick = (item: FileSystemItem) => {
+  const handleItemClick = async (item: FileSystemItem) => {
     if (item.isEncrypted && !decryptedUrls[item.id]) {
-      onDecrypt(item);
-    } else {
-      setLightboxItem(item);
+      await onDecrypt(item);
     }
+    setLightboxItem(item);
   };
 
   return (
@@ -151,7 +167,12 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ items, onNavigate, the
                   ) : (
                     <img src={decryptedUrls[item.id]} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110" alt={(item as any).decryptedName || item.name} />
                   )
-                ) : item.isEncrypted ? (
+                ) : decryptingIds.has(item.id) ? (
+                  <div className="w-full h-full flex flex-col items-center justify-center bg-zinc-900/80">
+                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-neon-green mb-2"></div>
+                    <p className="text-[10px] text-zinc-400 font-bold text-center px-2">Se decriptează...</p>
+                  </div>
+                ) : item.isEncrypted && item.salt ? (
                   <div className="w-full h-full flex flex-col items-center justify-center bg-zinc-900/80">
                     <Lock size={32} className="text-neon-green mb-2" />
                     <p className="text-[10px] text-zinc-400 font-bold text-center px-2">Click pentru a decripta</p>

--- a/components/views/GalleryView.tsx
+++ b/components/views/GalleryView.tsx
@@ -156,6 +156,12 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ items, onNavigate, the
                     <Lock size={32} className="text-neon-green mb-2" />
                     <p className="text-[10px] text-zinc-400 font-bold text-center px-2">Click pentru a decripta</p>
                   </div>
+                ) : item.url ? (
+                  item.category === 'video' ? (
+                    <video src={item.url} className="w-full h-full object-cover" muted />
+                  ) : (
+                    <img src={item.url} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110" alt={item.name} />
+                  )
                 ) : (
                   <div className="w-full h-full flex items-center justify-center text-muted">
                     <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-neon-green"></div>

--- a/components/views/SettingsView.tsx
+++ b/components/views/SettingsView.tsx
@@ -721,7 +721,7 @@ export const ThemesGalleryView: React.FC<{
       <div className="flex-1 overflow-y-auto px-5 py-6">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {displayThemes.map(theme => {
-                  const isActive = selectedThemeId === theme.id || (selectedThemeId === null && 
+                  const isActive = selectedThemeId === theme.id || (selectedThemeId === null && localStorage.getItem('theme_accent') === theme.accent && 
                                    getComputedStyle(document.documentElement).getPropertyValue('--bg-main').trim() === theme.bgMain);
                   const isLight = theme.textMain === '#09090b';
                   

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' 'sha256-OEPdcHzvKEr3pZVPkK7qb3CkSklneNEDL1ISFLi6KLc='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' 'sha256-OEPdcHzvKEr3pZVPkK7qb3CkSklneNEDL1ISFLi6KLc='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; media-src 'self' blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self';" />
     <title>CrytoTool</title>
     
     <script>


### PR DESCRIPTION
## Changes

### 1. CSP fix (index.html)
Added `blob:` to `img-src` and `media-src` in Content-Security-Policy. Blob URLs created from decrypted file data were being blocked by the browser, making all images invisible in the gallery.

### 2. Auto-decrypt + gallery UX (GalleryView.tsx)
- Files imported via the app are auto-encrypted by `addItem` (isEncrypted=true, no salt). Previously the gallery showed a lock icon requiring a click, and the click didn't open the lightbox because `onDecrypt` was async but not awaited.
- Added useEffect to auto-decrypt files without salt (no password needed) when the gallery mounts.
- Fixed `handleItemClick` to `await onDecrypt(item)` before opening the lightbox.
- Manual encrypted files (with salt) still show a lock icon and require password.

### 3. MIME type detection fix (Dashboard.tsx)
`addItem` calls `stripFromItem` which sets `item.name = ''`. The MIME type in `decryptOnDemand` used `item.name` for extension detection, always falling back to `image/jpeg`. Now uses `item.decryptedName || item.name` to correctly detect the extension.

### 4. Accent reset fix (Dashboard.tsx)
When user manually changes accent color, the accent useEffect now updates `app_theme_config` in localStorage so the manual accent persists across page reloads instead of reverting to the theme's original accent.