### PR TITLE
Remove duplicate decrypt button and encrypted overlay from lightbox

### DIFF
--- a/components/views/GalleryView.tsx
+++ b/components/views/GalleryView.tsx
@@ -55,7 +55,8 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ items, onNavigate, the
 
   const handleItemClick = async (item: FileSystemItem) => {
     if (item.isEncrypted && !decryptedUrls[item.id]) {
-      await onDecrypt(item);
+      const url = await onDecrypt(item);
+      if (!url) return;
     }
     setLightboxItem(item);
   };
@@ -82,12 +83,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ items, onNavigate, the
                 </div>
 
                 <div className="flex-1 flex items-center justify-center p-4 relative overflow-hidden">
-                    {lightboxItem.isEncrypted && !decryptedUrls[lightboxItem.id] ? (
-                      <div className="flex flex-col items-center gap-4">
-                        <Lock size={64} className="text-neon-green" />
-                        <p className="text-white text-lg font-bold">Fișier criptat</p>
-                      </div>
-                    ) : lightboxItem.category === 'video' ? (
+                    {lightboxItem.category === 'video' ? (
                         <video 
                             src={decryptedUrls[lightboxItem.id] || lightboxItem.url} 
                             controls 

--- a/components/views/GalleryView.tsx
+++ b/components/views/GalleryView.tsx
@@ -86,12 +86,6 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ items, onNavigate, the
                       <div className="flex flex-col items-center gap-4">
                         <Lock size={64} className="text-neon-green" />
                         <p className="text-white text-lg font-bold">Fișier criptat</p>
-                        <button 
-                          onClick={(e) => { e.stopPropagation(); onDecrypt(lightboxItem); }}
-                          className="px-6 py-3 bg-neon-green text-black font-bold rounded-xl"
-                        >
-                          Click pentru a decripta
-                        </button>
                       </div>
                     ) : lightboxItem.category === 'video' ? (
                         <video 


### PR DESCRIPTION
## Changes

### 1. Lightbox cleanup (GalleryView.tsx)
- Removed duplicate "Click pentru a decripta" button from lightbox (grid already shows this instruction)
- Removed lock icon and "Fișier criptat" text from lightbox
- `handleItemClick` now skips opening the lightbox entirely if decryption is cancelled/returns null

### Flow
1. Grid shows lock + "Click pentru a decripta" for manually encrypted items
2. Clicking opens decrypt modal directly
3. If password entered correctly → lightbox opens with the image
4. If cancelled → nothing happens (no empty lightbox shown)