### PR TITLE
Use dynamic accent color for music tab buttons instead of white

### DIFF
--- a/components/views/MusicView.tsx
+++ b/components/views/MusicView.tsx
@@ -52,7 +52,7 @@ export const MusicView: React.FC<MusicViewProps> = ({ items, onPlay, currentSong
           <button 
             key={tab.id} 
             onClick={() => setSubTab(tab.id as MusicSubTab)}
-            className={`px-5 py-2 rounded-full text-xs font-bold transition-all whitespace-nowrap border ${subTab === tab.id ? 'bg-white text-black border-white' : 'bg-zinc-900/50 text-zinc-400 border-zinc-800 backdrop-blur-md'}`}
+            className={`px-5 py-2 rounded-full text-xs font-bold transition-all whitespace-nowrap border ${subTab === tab.id ? 'bg-[var(--accent-color)] text-black border-[var(--accent-color)]' : 'bg-zinc-900/50 text-zinc-400 border-zinc-800 backdrop-blur-md'}`}
           >
             {tab.label}
           </button>


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Why is it needed? -->

**Issue:** <!-- Closes #..., Fixes #... -->

**Type:** Bug fix / New feature / Security fix / Refactor / Docs / CI / Breaking change

**Platform:** Desktop / Mobile / Web / All

---

## Changes

<!-- List key changes: added, modified, fixed, removed. Be concise. -->

-

---

## Protocol-3305 alignment

CrytoTool follows [Protocol-3305](https://github.com/ObscuritySecurity/protocol-3305).  
✓ = compliant, X = violation (blocking).

| Art. | Principle | Status | Notes |
| ---- | --------- | ------ | ----- |
| 0 | Ethical Monetization |  | |
| 1 | Privacy by Design | | |
| 2 | Security by Default |  | |
| 3 | Zero Trust |  | |
| 4 | Zero Knowledge |  | |
| 5 | Zero Personal Data Collection |  | |
| 6 | Zero Activity Logs |  | |
| 7 | Open Source |  | |
| 8 | Zero Non-Essential Permissions |  | |

---

## Checklist

- [ ] **PR does NOT modify cryptographic code, key derivation, or encryption algorithms**
- [ ] Tested on target platform(s)
- [ ] `npx tsc --noEmit` passed 
- [ ] Docs updated 
