### PR TITLE
Zero-knowledge key wrapping for recovery codes + in-memory MVK security fix

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,3 @@
-
 import React, { useState, useEffect, useRef } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { SplashScreen } from './components/SplashScreen';
@@ -8,27 +7,32 @@ import { cryptoService } from './utils/crypto';
 import { db } from './utils/db';
 import { I18nProvider } from './locales/i18nContext';
 import { hashPin } from './utils/security';
+import {
+  deriveKey,
+  wrapRawKey,
+  unwrapRawKey,
+  base64ToBytes,
+  bytesToBase64,
+  generateRecoveryCodes,
+  parseCodeIndex,
+} from './utils/keyWrapping';
+import type { CryptoMetadata, VaultWrappers } from './utils/keyWrapping';
 
 const App: React.FC = () => {
   const [showSplash, setShowSplash] = useState(true);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
 
-  useEffect(() => {
-    if (!showSplash) {
-      // StatusBar handled internally
-    }
-  }, [showSplash]);
-  
   const [isSetupRequired, setIsSetupRequired] = useState(() => {
     const salt = localStorage.getItem('crytotool_salt');
-    return !salt;
+    const wrappers = localStorage.getItem('crytotool_vault_wrappers');
+    return !salt && !wrappers;
   });
 
   const [autoBlurSeconds, setAutoBlurSeconds] = useState(() => {
     const saved = localStorage.getItem('crytotool_blur_time');
     return saved ? parseInt(saved, 10) : 20;
   });
-  
+
   const [autoLockSeconds, setAutoLockSeconds] = useState(() => {
     const saved = localStorage.getItem('crytotool_lock_time');
     return saved ? parseInt(saved, 10) : 25;
@@ -37,21 +41,16 @@ const App: React.FC = () => {
   const [isBlurred, setIsBlurred] = useState(false);
   const lastActivityRef = useRef(Date.now());
 
-  // --- SETTINGS LOCK ---
-  // Settings password is kept in memory only (not persisted) for security
   const [settingsPassword, setSettingsPassword] = useState<string | null>(null);
 
   const updateSettingsPassword = (pwd: string | null) => {
     setSettingsPassword(pwd);
   };
 
-  // --- VAULT SETTINGS (NEW) ---
-  // Vault is disabled by default for new people
   const [vaultEnabled, setVaultEnabled] = useState(() => {
     const saved = localStorage.getItem('crytotool_vault_enabled');
     return saved !== null ? saved === 'true' : false;
   });
-  // Vault PIN - stored as hash in localStorage
   const [vaultPin, setVaultPin] = useState<string | null>(() => {
     return localStorage.getItem('crytotool_vault_pin_hash');
   });
@@ -69,7 +68,6 @@ const App: React.FC = () => {
     localStorage.setItem('crytotool_vault_enabled', String(enabled));
   };
 
-  // --- PROGRESSIVE LOCK SETTINGS ---
   const [progressiveLockSeconds, setProgressiveLockSeconds] = useState(() => {
     const saved = localStorage.getItem('crytotool_prog_lock_time');
     return saved ? parseInt(saved, 10) : 60;
@@ -80,7 +78,6 @@ const App: React.FC = () => {
     return saved ? parseInt(saved, 10) : 3;
   });
 
-  // --- AUTO DESTRUCT SETTINGS ---
   const [autoDestructEnabled, setAutoDestructEnabled] = useState(() => {
     return localStorage.getItem('crytotool_ad_enabled') === 'true';
   });
@@ -92,7 +89,7 @@ const App: React.FC = () => {
 
   const [autoDestructInactivity, setAutoDestructInactivity] = useState(() => {
     const saved = localStorage.getItem('crytotool_ad_inactivity');
-    return saved ? parseInt(saved, 10) : 0; 
+    return saved ? parseInt(saved, 10) : 0;
   });
 
   const [destructCountdownSeconds, setDestructCountdownSeconds] = useState(() => {
@@ -112,6 +109,41 @@ const App: React.FC = () => {
     const saved = localStorage.getItem('crytotool_destruct_time');
     return saved ? parseInt(saved, 10) : null;
   });
+
+  const [newlyGeneratedCodes, setNewlyGeneratedCodes] = useState<string[] | null>(null);
+  const mvkBytesRef = useRef<Uint8Array | null>(null);
+  const [recoveryWrappersCount, setRecoveryWrappersCount] = useState(() => {
+    const raw = localStorage.getItem('crytotool_vault_wrappers');
+    if (!raw) return 0;
+    try {
+      const wrappers: VaultWrappers = JSON.parse(raw);
+      return Object.keys(wrappers.recovery || {}).length;
+    } catch { return 0; }
+  });
+
+  const syncRecoveryCount = () => {
+    const raw = localStorage.getItem('crytotool_vault_wrappers');
+    if (!raw) { setRecoveryWrappersCount(0); return; }
+    try {
+      const wrappers: VaultWrappers = JSON.parse(raw);
+      setRecoveryWrappersCount(Object.keys(wrappers.recovery || {}).length);
+    } catch { setRecoveryWrappersCount(0); }
+  };
+
+  const downloadCodes = (codes: string[]) => {
+    const header = 'CrytoTool Recovery Codes\nGenerated: ' + new Date().toISOString().split('T')[0] + '\n\u2500'.repeat(30) + '\n\n';
+    const content = header + codes.join('\n');
+    const blob = new Blob([content], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'crytotool-recovery-codes.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const [failedAttempts, setFailedAttempts] = useState(0);
+  const [lockUntil, setLockUntil] = useState<number | null>(null);
 
   useEffect(() => {
     if (!isAuthenticated || !autoDestructEnabled || autoDestructInactivity === 0) return;
@@ -186,130 +218,20 @@ const App: React.FC = () => {
     return () => clearInterval(intervalId);
   }, [isAuthenticated, destructTriggerTime]);
 
-  // --- RECOVERY CODES (Encrypted with Vault Key) ---
-  const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
-  
-  useEffect(() => {
-    const loadRecoveryCodes = async () => {
-      const saved = localStorage.getItem('crytotool_recovery_codes');
-      if (!saved) return;
-      try {
-        const parsed = JSON.parse(saved);
-        if (parsed.iv && parsed.data) {
-          const decrypted = await cryptoService.decryptString(parsed.data, parsed.iv);
-          setRecoveryCodes(JSON.parse(decrypted));
-        } else {
-          setRecoveryCodes(parsed); // Legacy plaintext
-        }
-      } catch {
-        setRecoveryCodes([]);
-      }
-    };
-    
-    if (isAuthenticated) {
-      loadRecoveryCodes();
-    }
-  }, [isAuthenticated]);
-
-  const generateRecoveryCodes = (): string[] => {
-    const codes: string[] = [];
-    const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
-    for (let i = 0; i < 10; i++) {
-      let code = '';
-      const randomValues = new Uint8Array(8);
-      window.crypto.getRandomValues(randomValues);
-      for (let j = 0; j < 8; j++) {
-        code += chars[randomValues[j] % chars.length];
-        if ((j + 1) % 4 === 0 && j !== 7) code += '-';
-      }
-      codes.push(code);
-    }
-    return codes;
-  };
-
-  const saveRecoveryCodes = async (codes: string[]) => {
-    try {
-      const jsonString = JSON.stringify(codes);
-      const encrypted = await cryptoService.encryptString(jsonString);
-      const stored = JSON.stringify({ iv: encrypted.iv, data: encrypted.ciphertext });
-      localStorage.setItem('crytotool_recovery_codes', stored);
-    } catch {
-      // Vault Key not available, save plaintext (fallback)
-      localStorage.setItem('crytotool_recovery_codes', JSON.stringify(codes));
-    }
-  };
-
-  const regenerateRecoveryCodes = () => {
-    const newCodes = generateRecoveryCodes();
-    setRecoveryCodes(newCodes);
-    saveRecoveryCodes(newCodes);
-  };
-
-  const verifyRecoveryCode = (code: string): boolean => {
-    return recoveryCodes.includes(code.replace(/-/g, '').toUpperCase());
-  };
-
-  const consumeRecoveryCode = (code: string) => {
-    const normalizedCode = code.replace(/-/g, '').toUpperCase();
-    if (recoveryCodes.includes(normalizedCode)) {
-      const updatedCodes = recoveryCodes.filter(c => c.replace(/-/g, '') !== normalizedCode);
-      setRecoveryCodes(updatedCodes);
-      saveRecoveryCodes(updatedCodes);
-      return true;
-    }
-    return false;
-  };
-
-  const resetMasterPasswordWithRecovery = async (code: string, newPassword: string) => {
-    if (!consumeRecoveryCode(code)) {
-      return { success: false, error: 'Cod invalid' };
-    }
-
-    try {
-      // Generate new salt and derive new master key
-      const salt = window.crypto.getRandomValues(new Uint8Array(16));
-      const masterKey = await cryptoService.deriveMasterKey(newPassword, salt);
-      const vaultKey = await cryptoService.generateVaultKey();
-      const rawVaultKey = await window.crypto.subtle.exportKey('raw', vaultKey);
-      const encryptedVault = await cryptoService.encrypt(new Uint8Array(rawVaultKey), masterKey);
-
-      // Save new credentials
-      localStorage.setItem('crytotool_salt', cryptoService.arrayBufferToBase64(salt));
-      localStorage.setItem('crytotool_iv', cryptoService.arrayBufferToBase64(encryptedVault.iv));
-      localStorage.setItem('crytotool_vault_blob', cryptoService.arrayBufferToBase64(encryptedVault.ciphertext));
-
-      cryptoService.setVaultKey(vaultKey);
-
-      return { success: true };
-    } catch (e) {
-      return { success: false, error: 'Eroare la resetare' };
-    }
-  };
-
-  const [failedAttempts, setFailedAttempts] = useState(0);
-  const [lockUntil, setLockUntil] = useState<number | null>(null);
-
-  // Auto-destruct on inactivity is implemented as part of the activity timer below.
-  // We intentionally avoid persisting any activity logs; this check relies on in-memory
-  // timestamps to determine inactivity.
-  useEffect(() => {
-    // no-op: we keep this hook for parity, actual destruction is handled in the main timer
-  }, [autoDestructEnabled, autoDestructInactivity, isSetupRequired]);
-
   const performWipe = async () => {
     try {
-        await db.clearDatabase();
-        localStorage.clear();
-        sessionStorage.clear();
-        cryptoService.clearKeys();
-        window.location.reload();
+      await db.clearDatabase();
+      localStorage.clear();
+      sessionStorage.clear();
+      cryptoService.clearKeys();
+      window.location.reload();
     } catch (e) {
-        localStorage.clear();
-        window.location.reload();
+      localStorage.clear();
+      window.location.reload();
     }
   };
 
-  const handleUnlock = (vaultKey: CryptoKey) => {
+  const handleUnlock = () => {
     setIsAuthenticated(true);
     setIsSetupRequired(false);
     setIsBlurred(false);
@@ -321,7 +243,7 @@ const App: React.FC = () => {
   const handleFailedAttempt = () => {
     const newCount = failedAttempts + 1;
     setFailedAttempts(newCount);
-    
+
     if (autoDestructEnabled && autoDestructAttempts > 0) {
       if (newCount >= autoDestructAttempts) {
         if (!destructTriggerTime) {
@@ -340,12 +262,10 @@ const App: React.FC = () => {
   };
 
   const handleLock = () => {
-    if (isAuthenticated) {
-        // Do not persist last login timestamp
-    }
     setIsAuthenticated(false);
     setIsBlurred(false);
     cryptoService.clearKeys();
+    mvkBytesRef.current = null;
   };
 
   useEffect(() => {
@@ -384,6 +304,95 @@ const App: React.FC = () => {
     };
   }, [isAuthenticated, isBlurred, autoBlurSeconds, autoLockSeconds, autoDestructInactivity, autoDestructEnabled]);
 
+  const resetMasterPasswordWithRecovery = async (code: string, newPassword: string): Promise<{ success: boolean; error?: string }> => {
+    try {
+      const idx = parseCodeIndex(code);
+      if (!idx) return { success: false, error: 'Format cod invalid' };
+
+      const wrappersRaw = localStorage.getItem('crytotool_vault_wrappers');
+      const metadataRaw = localStorage.getItem('crytotool_crypto_metadata');
+      if (!wrappersRaw || !metadataRaw) return { success: false, error: 'Date lipsă' };
+
+      const wrappers: VaultWrappers = JSON.parse(wrappersRaw);
+      const meta: CryptoMetadata = JSON.parse(metadataRaw);
+
+      const recoveryWrapper = wrappers.recovery[idx];
+      if (!recoveryWrapper) return { success: false, error: 'Cod de recuperare deja folosit sau invalid' };
+
+      const saltIdx = parseInt(idx, 10) - 1;
+      if (saltIdx < 0 || saltIdx >= meta.recovery_salts.length) return { success: false, error: 'Salt lipsă' };
+
+      const recoverySalt = base64ToBytes(meta.recovery_salts[saltIdx]);
+      const recoveryKey = await deriveKey(code, recoverySalt, { iterations: 3, memorySize: 65536, parallelism: 1 });
+
+      let mvkBytes: Uint8Array;
+      try {
+        mvkBytes = await unwrapRawKey(recoveryWrapper, recoveryKey);
+      } catch {
+        return { success: false, error: 'Cod de recuperare invalid' };
+      }
+
+      const newMasterSalt = window.crypto.getRandomValues(new Uint8Array(16));
+      const newMasterKey = await deriveKey(newPassword, newMasterSalt, { iterations: 19, memorySize: 131072, parallelism: 4 });
+      const newMasterWrapper = await wrapRawKey(mvkBytes, newMasterKey);
+
+      delete wrappers.recovery[idx];
+      meta.master_salt = bytesToBase64(newMasterSalt);
+      wrappers.master = newMasterWrapper;
+
+      localStorage.setItem('crytotool_crypto_metadata', JSON.stringify(meta));
+      localStorage.setItem('crytotool_vault_wrappers', JSON.stringify(wrappers));
+
+      const mvk = await window.crypto.subtle.importKey(
+        'raw',
+        mvkBytes as unknown as BufferSource,
+        { name: 'AES-GCM' },
+        true,
+        ['encrypt', 'decrypt']
+      );
+      cryptoService.setVaultKey(mvk);
+      mvkBytesRef.current = mvkBytes;
+      syncRecoveryCount();
+
+      return { success: true };
+    } catch (e) {
+      return { success: false, error: 'Eroare la resetare' };
+    }
+  };
+
+  const generateNewRecoveryCodes = async () => {
+    if (!mvkBytesRef.current) return;
+    const mvkBytes = mvkBytesRef.current;
+
+    const codes = generateRecoveryCodes();
+    const salts: string[] = [];
+    const recoveryWrappers: Record<string, { ciphertext: string; iv: string }> = {};
+
+    for (let i = 0; i < codes.length; i++) {
+      const salt = window.crypto.getRandomValues(new Uint8Array(16));
+      salts.push(bytesToBase64(salt));
+      const key = await deriveKey(codes[i], salt, { iterations: 3, memorySize: 65536, parallelism: 1 });
+      const paddedIdx = String(i + 1).padStart(2, '0');
+      recoveryWrappers[paddedIdx] = await wrapRawKey(mvkBytes, key);
+    }
+
+    const metaRaw = localStorage.getItem('crytotool_crypto_metadata');
+    if (!metaRaw) return;
+    const meta: CryptoMetadata = JSON.parse(metaRaw);
+    meta.recovery_salts = salts;
+    localStorage.setItem('crytotool_crypto_metadata', JSON.stringify(meta));
+
+    const wrappersRaw = localStorage.getItem('crytotool_vault_wrappers');
+    if (!wrappersRaw) return;
+    const wrappers: VaultWrappers = JSON.parse(wrappersRaw);
+    wrappers.recovery = recoveryWrappers;
+    localStorage.setItem('crytotool_vault_wrappers', JSON.stringify(wrappers));
+
+    setNewlyGeneratedCodes(codes);
+    downloadCodes(codes);
+    syncRecoveryCount();
+  };
+
   return (
     <I18nProvider>
     <div className="w-full min-h-screen bg-background text-primary font-sans selection:bg-neon-green selection:text-black relative">
@@ -392,51 +401,55 @@ const App: React.FC = () => {
           <SplashScreen key="splash" onComplete={() => setShowSplash(false)} />
         ) : !isAuthenticated ? (
           <motion.div key="auth" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
-            <AuthScreen 
-              onUnlock={handleUnlock} 
-              isSetup={isSetupRequired} 
+            <AuthScreen
+              onUnlock={handleUnlock}
+              isSetup={isSetupRequired}
               lockUntil={lockUntil}
               onFailedAttempt={handleFailedAttempt}
               recoverySettings={{
-                verify: verifyRecoveryCode,
-                consume: consumeRecoveryCode,
-                codes: recoveryCodes
+                count: recoveryWrappersCount
               }}
               onResetWithRecovery={resetMasterPasswordWithRecovery}
+              onStoreMvkBytes={(bytes) => { mvkBytesRef.current = bytes; }}
               destructCountdown={destructCountdown}
+              onNewCodes={(codes) => {
+                setNewlyGeneratedCodes(codes);
+                downloadCodes(codes);
+                syncRecoveryCount();
+              }}
             />
           </motion.div>
         ) : (
            <motion.div key="dashboard" initial={{ opacity: 0, scale: 0.98 }} animate={{ opacity: 1, scale: 1 }} className="relative h-full">
-              <Dashboard 
+              <Dashboard
                 settingsLock={{
                   password: settingsPassword,
                   setPassword: updateSettingsPassword
                 }}
                 recoverySettings={{
-                  codes: recoveryCodes,
-                  regenerate: regenerateRecoveryCodes,
-                  verify: verifyRecoveryCode,
-                  consume: consumeRecoveryCode
+                  codes: newlyGeneratedCodes,
+                  count: recoveryWrappersCount,
+                  regenerate: generateNewRecoveryCodes,
+                  dismissCodes: () => setNewlyGeneratedCodes(null)
                 }}
                 vaultSettings={{
                   enabled: vaultEnabled,
                   pin: vaultPin,
                   update: updateVaultSettings
                 }}
-               autoBlurSettings={{ 
-                 value: autoBlurSeconds, 
-                 setValue: (v) => { 
-                   setAutoBlurSeconds(v); 
-                   localStorage.setItem('crytotool_blur_time', v.toString()); 
-                 } 
+               autoBlurSettings={{
+                 value: autoBlurSeconds,
+                 setValue: (v) => {
+                   setAutoBlurSeconds(v);
+                   localStorage.setItem('crytotool_blur_time', v.toString());
+                 }
                }}
-               autoLockSettings={{ 
-                 value: autoLockSeconds, 
-                 setValue: (v) => { 
-                   setAutoLockSeconds(v); 
-                   localStorage.setItem('crytotool_lock_time', v.toString()); 
-                 } 
+               autoLockSettings={{
+                 value: autoLockSeconds,
+                 setValue: (v) => {
+                   setAutoLockSeconds(v);
+                   localStorage.setItem('crytotool_lock_time', v.toString());
+                 }
                }}
                progressiveLockSettings={{
                  lockTime: progressiveLockSeconds,
@@ -474,10 +487,10 @@ const App: React.FC = () => {
                 }}
                 destructCountdown={destructCountdown}
               />
-             
+
               <AnimatePresence>
                 {isBlurred && (
-                  <motion.div 
+                  <motion.div
                     initial={{ opacity: 0, backdropFilter: "blur(0px)" }}
                     animate={{ opacity: 1, backdropFilter: "blur(40px)" }}
                     exit={{ opacity: 0, backdropFilter: "blur(0px)" }}

--- a/components/AuthScreen.tsx
+++ b/components/AuthScreen.tsx
@@ -1,25 +1,33 @@
-
 import React, { useState, useEffect } from 'react';
 import { Eye, EyeOff, Key, Loader2, ShieldCheck, Timer, ShieldAlert } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { cryptoService } from '../utils/crypto';
 import { useI18n } from '../locales/i18nContext';
+import {
+  deriveKey,
+  wrapRawKey,
+  unwrapRawKey,
+  bytesToBase64,
+  base64ToBytes,
+  generateRecoveryCodes,
+} from '../utils/keyWrapping';
+import type { CryptoMetadata, VaultWrappers } from '../utils/keyWrapping';
 
 interface AuthScreenProps {
-  onUnlock: (vaultKey: CryptoKey) => void;
+  onUnlock: () => void;
   isSetup: boolean;
   lockUntil: number | null;
   onFailedAttempt: () => void;
   recoverySettings?: {
-    verify: (code: string) => boolean;
-    consume: (code: string) => boolean;
-    codes: string[];
+    count: number;
   };
   onResetWithRecovery: (code: string, newPassword: string) => Promise<{ success: boolean; error?: string }>;
   destructCountdown?: number | null;
+  onNewCodes?: (codes: string[]) => void;
+  onStoreMvkBytes?: (bytes: Uint8Array) => void;
 }
 
-export const AuthScreen: React.FC<AuthScreenProps> = ({ onUnlock, isSetup, lockUntil, onFailedAttempt, recoverySettings, onResetWithRecovery }) => {
+export const AuthScreen: React.FC<AuthScreenProps> = ({ onUnlock, isSetup, lockUntil, onFailedAttempt, recoverySettings, onResetWithRecovery, onNewCodes, onStoreMvkBytes }) => {
   const { t } = useI18n();
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -27,8 +35,7 @@ export const AuthScreen: React.FC<AuthScreenProps> = ({ onUnlock, isSetup, lockU
   const [error, setError] = useState<string | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [timeLeft, setTimeLeft] = useState(0);
-  
-  // Recovery mode state
+
   const [isRecoveryMode, setIsRecoveryMode] = useState(false);
   const [recoveryCode, setRecoveryCode] = useState('');
   const [newRecoveryPassword, setNewRecoveryPassword] = useState('');
@@ -39,8 +46,7 @@ export const AuthScreen: React.FC<AuthScreenProps> = ({ onUnlock, isSetup, lockU
     const c = accentColor.replace('#', '');
     return `${parseInt(c.slice(0, 2), 16)}, ${parseInt(c.slice(2, 4), 16)}, ${parseInt(c.slice(4, 6), 16)}`;
   })();
-  
-  // Read theme config for background
+
   const themeConfig = (() => {
     try {
       const saved = localStorage.getItem('app_theme_config');
@@ -86,51 +92,111 @@ export const AuthScreen: React.FC<AuthScreenProps> = ({ onUnlock, isSetup, lockU
           return;
         }
 
-        const salt = window.crypto.getRandomValues(new Uint8Array(16));
-        const masterKey = await cryptoService.deriveMasterKey(password, salt);
-        const vaultKey = await cryptoService.generateVaultKey();
-        const rawVaultKey = await window.crypto.subtle.exportKey('raw', vaultKey);
-        const encryptedVault = await cryptoService.encrypt(new Uint8Array(rawVaultKey), masterKey);
-        
-        localStorage.setItem('crytotool_salt', cryptoService.arrayBufferToBase64(salt));
-        localStorage.setItem('crytotool_iv', cryptoService.arrayBufferToBase64(encryptedVault.iv));
-        localStorage.setItem('crytotool_vault_blob', cryptoService.arrayBufferToBase64(encryptedVault.ciphertext));
-        
-        cryptoService.setVaultKey(vaultKey);
-        onUnlock(vaultKey);
-      } else {
-        const saltB64 = localStorage.getItem('crytotool_salt');
-        const ivB64 = localStorage.getItem('crytotool_iv');
-        const vaultB64 = localStorage.getItem('crytotool_vault_blob');
+        const mvk = await cryptoService.generateVaultKey();
+        const rawMvk = await window.crypto.subtle.exportKey('raw', mvk);
+        const mvkBytes = new Uint8Array(rawMvk);
 
-        if (!saltB64 || !ivB64 || !vaultB64) {
-          setError(t('missingData'));
-          setIsProcessing(false);
-          return;
+        const codes = generateRecoveryCodes();
+
+        const masterSalt = window.crypto.getRandomValues(new Uint8Array(16));
+        const masterKey = await deriveKey(password, masterSalt, { iterations: 19, memorySize: 131072, parallelism: 4 });
+        const masterWrapper = await wrapRawKey(mvkBytes, masterKey);
+
+        const recoverySalts: string[] = [];
+        const recoveryWrappers: Record<string, { ciphertext: string; iv: string }> = {};
+
+        for (let i = 0; i < codes.length; i++) {
+          const salt = window.crypto.getRandomValues(new Uint8Array(16));
+          recoverySalts.push(bytesToBase64(salt));
+          const key = await deriveKey(codes[i], salt, { iterations: 3, memorySize: 65536, parallelism: 1 });
+          const paddedIdx = String(i + 1).padStart(2, '0');
+          recoveryWrappers[paddedIdx] = await wrapRawKey(mvkBytes, key);
         }
 
-        const salt = cryptoService.base64ToArrayBuffer(saltB64);
-        const iv = cryptoService.base64ToArrayBuffer(ivB64);
-        const encryptedVault = cryptoService.base64ToArrayBuffer(vaultB64);
+        const meta: CryptoMetadata = {
+          master_salt: bytesToBase64(masterSalt),
+          recovery_salts: recoverySalts,
+        };
+        const wrappers: VaultWrappers = {
+          master: masterWrapper,
+          recovery: recoveryWrappers,
+        };
 
-        const masterKey = await cryptoService.deriveMasterKey(password, salt);
+        localStorage.setItem('crytotool_crypto_metadata', JSON.stringify(meta));
+        localStorage.setItem('crytotool_vault_wrappers', JSON.stringify(wrappers));
 
-        try {
-          const rawVaultKey = await cryptoService.decrypt(encryptedVault, iv, masterKey);
-          const vaultKey = await window.crypto.subtle.importKey(
-            'raw',
-            rawVaultKey.buffer as ArrayBuffer,
-            { name: 'AES-GCM' },
-            true,
-            ['encrypt', 'decrypt']
-          );
-          
-          cryptoService.setVaultKey(vaultKey);
-          onUnlock(vaultKey);
-        } catch (err) {
-          setError(t('wrongPassword'));
-          setPassword('');
-          onFailedAttempt();
+        cryptoService.setVaultKey(mvk);
+        onStoreMvkBytes?.(mvkBytes);
+        onNewCodes?.(codes);
+        onUnlock();
+      } else {
+        const wrappersRaw = localStorage.getItem('crytotool_vault_wrappers');
+        if (wrappersRaw) {
+          const metadataRaw = localStorage.getItem('crytotool_crypto_metadata');
+          if (!metadataRaw) {
+            setError(t('missingData'));
+            setIsProcessing(false);
+            return;
+          }
+
+          const wrappers: VaultWrappers = JSON.parse(wrappersRaw);
+          const meta: CryptoMetadata = JSON.parse(metadataRaw);
+          const masterSalt = base64ToBytes(meta.master_salt);
+
+          const masterKey = await deriveKey(password, masterSalt, { iterations: 19, memorySize: 131072, parallelism: 4 });
+
+          try {
+            const mvkBytes = await unwrapRawKey(wrappers.master, masterKey);
+            const mvk = await window.crypto.subtle.importKey(
+              'raw',
+              mvkBytes as unknown as BufferSource,
+              { name: 'AES-GCM' },
+              true,
+              ['encrypt', 'decrypt']
+            );
+
+            cryptoService.setVaultKey(mvk);
+            onStoreMvkBytes?.(mvkBytes);
+            onUnlock();
+          } catch (err) {
+            setError(t('wrongPassword'));
+            setPassword('');
+            onFailedAttempt();
+          }
+        } else {
+          const saltB64 = localStorage.getItem('crytotool_salt');
+          const ivB64 = localStorage.getItem('crytotool_iv');
+          const vaultB64 = localStorage.getItem('crytotool_vault_blob');
+
+          if (!saltB64 || !ivB64 || !vaultB64) {
+            setError(t('missingData'));
+            setIsProcessing(false);
+            return;
+          }
+
+          const salt = cryptoService.base64ToArrayBuffer(saltB64);
+          const iv = cryptoService.base64ToArrayBuffer(ivB64);
+          const encryptedVault = cryptoService.base64ToArrayBuffer(vaultB64);
+
+          const masterKey = await cryptoService.deriveMasterKey(password, salt);
+
+          try {
+            const rawVaultKey = await cryptoService.decrypt(encryptedVault, iv, masterKey);
+            const vaultKey = await window.crypto.subtle.importKey(
+              'raw',
+              rawVaultKey.buffer as ArrayBuffer,
+              { name: 'AES-GCM' },
+              true,
+              ['encrypt', 'decrypt']
+            );
+
+            cryptoService.setVaultKey(vaultKey);
+            onUnlock();
+          } catch (err) {
+            setError(t('wrongPassword'));
+            setPassword('');
+            onFailedAttempt();
+          }
         }
       }
     } catch (err) {
@@ -147,7 +213,7 @@ export const AuthScreen: React.FC<AuthScreenProps> = ({ onUnlock, isSetup, lockU
       <svg viewBox="0 0 100 100" className="w-full h-full" style={{ filter: `drop-shadow(0 0 15px rgba(${isLocked ? '239, 68, 68' : accentRgb}, 0.5))` }}>
         <path d="M30 40 V25 A20 20 0 0 1 70 25 V40" stroke={isLocked ? '#ef4444' : accentColor} strokeWidth="10" strokeLinecap="round" fill="none" className="transition-colors duration-500" />
         <rect x="15" y="40" width="70" height="45" rx="10" fill="none" stroke={isLocked ? '#ef4444' : accentColor} strokeWidth="8" className="transition-colors duration-500" />
-        
+
         {isLocked ? (
            <path d="M40 55 L60 75 M60 55 L40 75" stroke="#ef4444" strokeWidth="6" strokeLinecap="round" fill="none" />
         ) : (
@@ -168,7 +234,7 @@ export const AuthScreen: React.FC<AuthScreenProps> = ({ onUnlock, isSetup, lockU
         <p className="text-sm text-muted mb-6 tracking-wide">All-in-One Privacy</p>
       </div>
 
-      <motion.div 
+      <motion.div
         initial={{ y: 20, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         className={`w-full max-w-md glass-card border ${isLocked ? 'border-red-500/50' : 'border-white/10'} rounded-3xl p-6 relative overflow-hidden mt-8`}
@@ -178,10 +244,10 @@ export const AuthScreen: React.FC<AuthScreenProps> = ({ onUnlock, isSetup, lockU
             {isLocked ? t('lockedOut') : (isSetup ? t('setupPassword') : t('unlock'))}
           </h1>
           <p className="text-muted text-sm leading-relaxed">
-            {isLocked 
+            {isLocked
               ? `${t('securityLockout')} ${t('tryAgainIn')} ${timeLeft} ${t('processing')}`
-              : (isSetup 
-                  ? `${t('argon2idAES')} ${t('min30Chars')}` 
+              : (isSetup
+                  ? `${t('argon2idAES')} ${t('min30Chars')}`
                   : t('enterMasterPassword')
                 )
             }
@@ -189,7 +255,7 @@ export const AuthScreen: React.FC<AuthScreenProps> = ({ onUnlock, isSetup, lockU
         </div>
 
         {isLocked && (
-          <motion.div 
+          <motion.div
             initial={{ opacity: 0, scale: 0.9 }}
             animate={{ opacity: 1, scale: 1 }}
             className="flex flex-col items-center justify-center p-8 bg-red-500/5 rounded-2xl border border-red-500/10 mb-6"
@@ -213,7 +279,7 @@ export const AuthScreen: React.FC<AuthScreenProps> = ({ onUnlock, isSetup, lockU
                 autoFocus
               />
               <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-3 text-muted">
-                <button 
+                <button
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
                   className="hover:text-primary transition-colors"
@@ -264,8 +330,7 @@ export const AuthScreen: React.FC<AuthScreenProps> = ({ onUnlock, isSetup, lockU
           </button>
         </form>
 
-        {/* Recovery Mode Button */}
-        {!isSetup && !isLocked && recoverySettings && recoverySettings.codes.length > 0 && (
+        {!isSetup && !isLocked && recoverySettings && recoverySettings.count > 0 && (
           <div className="mt-4 pt-4 border-t border-white/10">
             <button
               type="button"
@@ -277,28 +342,27 @@ export const AuthScreen: React.FC<AuthScreenProps> = ({ onUnlock, isSetup, lockU
           </div>
         )}
 
-        {/* Recovery Mode Form */}
         {isRecoveryMode && (
-          <motion.div 
+          <motion.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             className="mt-4 p-4 rounded-2xl bg-zinc-900/80 border border-zinc-800"
           >
             <h3 className="text-sm font-bold text-white mb-3">Reset with Recovery Code</h3>
-            
+
             <div className="space-y-3">
               <div>
                 <label className="text-[10px] text-zinc-500 uppercase tracking-wider">Recovery Code</label>
                 <input
                   type="text"
                   value={recoveryCode}
-                  onChange={(e) => setRecoveryCode(e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, ''))}
-                  placeholder="XXXX-XXXX-XXXX-XXXX"
+                  onChange={(e) => setRecoveryCode(e.target.value.toUpperCase().replace(/[^A-Z0-9-]/g, ''))}
+                  placeholder="CRYTO-XX-XXXX-XXXX-XXXX"
                   className="w-full bg-black border border-zinc-700 text-white rounded-lg px-3 py-2 text-sm font-mono mt-1"
-                  maxLength={19}
+                  maxLength={23}
                 />
               </div>
-              
+
               <div>
                 <label className="text-[10px] text-zinc-500 uppercase tracking-wider">New Password (min 30 chars)</label>
                 <input
@@ -348,17 +412,12 @@ export const AuthScreen: React.FC<AuthScreenProps> = ({ onUnlock, isSetup, lockU
                       setError('Passwords do not match');
                       return;
                     }
-                    if (!recoverySettings?.verify(recoveryCode)) {
-                      setError('Invalid recovery code');
-                      return;
-                    }
 
                     setIsProcessing(true);
                     const result = await onResetWithRecovery(recoveryCode, newRecoveryPassword);
                     setIsProcessing(false);
 
                     if (result.success) {
-                      // Reset successful, reload page to re-authenticate with new credentials
                       window.location.reload();
                     } else {
                       setError(result.error || 'Reset error');

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -23,6 +23,7 @@ import { PinModal } from './PinModal';
 import { EncryptionModal } from './EncryptionModal';
 import { DecryptModal } from './DecryptModal';
 import { CopyMoveModal } from './CopyMoveModal';
+import { RecoveryCodesModal } from './RecoveryCodesModal';
 
 // Import Views
 import { StorageView } from './views/StorageView';
@@ -40,10 +41,10 @@ interface DashboardProps {
     setPassword: (pwd: string | null) => void;
   };
   recoverySettings: {
-    codes: string[];
+    codes: string[] | null;
+    count: number;
     regenerate: () => void;
-    verify: (code: string) => boolean;
-    consume: (code: string) => boolean;
+    dismissCodes: () => void;
   };
   vaultSettings: {
     enabled: boolean;
@@ -127,6 +128,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
   progressiveLockSettings,
   autoDestructSettings 
 }) => {
+  const [showCodesModal, setShowCodesModal] = useState(false);
   const { t } = useI18n();
   const [activeTab, setActiveTab] = useState('files');
   const [currentView, setCurrentView] = useState<ViewState | 'backup'>('dashboard');
@@ -242,6 +244,12 @@ export const Dashboard: React.FC<DashboardProps> = ({
         Object.values(decryptedUrls).forEach(url => URL.revokeObjectURL(url as string));
     };
   }, []);
+
+  useEffect(() => {
+    if (recoverySettings.codes && recoverySettings.codes.length > 0) {
+      setShowCodesModal(true);
+    }
+  }, [recoverySettings.codes]);
 
   // --- NAVIGATION HANDLER WITH LOCK ---
   const handleViewNavigation = (view: ViewState) => {
@@ -784,6 +792,29 @@ export const Dashboard: React.FC<DashboardProps> = ({
                 onSuccess={handlePinSuccess}
                 onClose={() => { setShowPinModal(false); setPendingVaultAction(null); }}
             />
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {showCodesModal && recoverySettings.codes && (
+          <RecoveryCodesModal
+            codes={recoverySettings.codes}
+            onDownload={() => {
+              const header = 'CrytoTool Recovery Codes\nGenerated: ' + new Date().toISOString().split('T')[0] + '\n\u2500'.repeat(30) + '\n\n';
+              const content = header + recoverySettings.codes!.join('\n');
+              const blob = new Blob([content], { type: 'text/plain' });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = 'crytotool-recovery-codes.txt';
+              a.click();
+              URL.revokeObjectURL(url);
+            }}
+            onDismiss={() => {
+              recoverySettings.dismissCodes();
+              setShowCodesModal(false);
+            }}
+          />
         )}
       </AnimatePresence>
       

--- a/components/RecoveryCodesModal.tsx
+++ b/components/RecoveryCodesModal.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { ShieldAlert, Download, X, KeyRound } from 'lucide-react';
+
+interface RecoveryCodesModalProps {
+  codes: string[];
+  onDownload: () => void;
+  onDismiss: () => void;
+}
+
+export const RecoveryCodesModal: React.FC<RecoveryCodesModalProps> = ({ codes, onDownload, onDismiss }) => {
+  return (
+    <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/80 backdrop-blur-xl p-4">
+      <motion.div
+        initial={{ scale: 0.9, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        exit={{ scale: 0.9, opacity: 0 }}
+        className="w-full max-w-lg glass-card rounded-[40px] p-8 relative overflow-hidden"
+      >
+        <div className="flex flex-col items-center mb-6">
+          <div className="w-16 h-16 rounded-2xl bg-yellow-500/10 text-yellow-500 flex items-center justify-center mb-4">
+            <KeyRound size={32} />
+          </div>
+          <h2 className="text-xl font-bold text-white mb-1">Recovery Codes</h2>
+          <p className="text-xs text-zinc-500 text-center px-4">
+            Save these codes in a safe place. Each code can be used only once to reset your Master password without losing data.
+          </p>
+        </div>
+
+        <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-xl p-3 mb-4">
+          <p className="text-[11px] text-yellow-500 font-bold text-center flex items-center justify-center gap-2">
+            <ShieldAlert size={14} />
+            These codes will only be shown once. Download them now.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2 mb-6">
+          {codes.map((code, idx) => (
+            <div
+              key={idx}
+              className="px-3 py-2 rounded-xl bg-black/50 text-xs font-mono text-zinc-300 text-center border border-zinc-800 tracking-wider"
+            >
+              {code}
+            </div>
+          ))}
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            onClick={onDownload}
+            className="flex-1 py-3 rounded-2xl bg-neon-green text-black text-xs font-bold hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+          >
+            <Download size={16} />
+            Download
+          </button>
+          <button
+            onClick={onDismiss}
+            className="flex-1 py-3 rounded-2xl border border-zinc-700 text-zinc-400 text-xs font-bold hover:bg-zinc-800 transition-colors flex items-center justify-center gap-2"
+          >
+            <X size={16} />
+            Dismiss
+          </button>
+        </div>
+      </motion.div>
+    </div>
+  );
+};

--- a/components/views/SettingsView.tsx
+++ b/components/views/SettingsView.tsx
@@ -11,6 +11,7 @@ import {
 import { AppTheme, ThemeConfig, ThemeCategory, FontCategory, FontConfig } from '../../types';
 import { CustomColorPicker } from '../CustomColorPicker';
 import { CustomSelect } from '../CustomSelect';
+
 import { THEME_COLLECTIONS, CATEGORY_KEYS, getAllThemes } from '../../styles/themes';
 import { FONT_LIST, FONT_CATEGORIES, getFontsByCategory } from '../../styles/fonts';
 import { LANGUAGES } from '../../locales';
@@ -45,8 +46,10 @@ interface SettingsViewProps {
     setPassword: (pwd: string | null) => void;
   };
   recoverySettings: {
-    codes: string[];
+    codes: string[] | null;
+    count: number;
     regenerate: () => void;
+    dismissCodes: () => void;
   };
   vaultSettings: {
     enabled: boolean;
@@ -64,7 +67,6 @@ export const SettingsView: React.FC<SettingsViewProps> = (props) => {
     const [region, setRegion] = useState('Bucharest');
     const [isLangOpen, setIsLangOpen] = useState(false);
     const [isRegionOpen, setIsRegionOpen] = useState(false);
-
     // State for settings password modification
     const [isSettingPassword, setIsSettingPassword] = useState(false);
     const [newSettingsPwd, setNewSettingsPwd] = useState('');
@@ -576,7 +578,7 @@ export const SettingsView: React.FC<SettingsViewProps> = (props) => {
                     </div>
                 </div>
 
-                {/* RECOVERY CODES SECTION */}
+                    {/* RECOVERY CODES SECTION */}
                 <div className="border-t border-border pt-6 mt-4">
                     <h4 className="text-[10px] font-black uppercase tracking-widest text-neon-green flex items-center gap-2 mb-4">
                         <KeyRound size={14} /> Password Recovery
@@ -586,29 +588,23 @@ export const SettingsView: React.FC<SettingsViewProps> = (props) => {
                         <div className="flex items-center justify-between mb-3">
                             <div>
                                 <p className="text-xs font-bold text-white">Recovery Codes</p>
-                                <p className="text-[10px] text-zinc-500">{props.recoverySettings.codes.length}/10 codes available</p>
+                                <p className="text-[10px] text-zinc-500">{props.recoverySettings.count}/10 codes available</p>
                             </div>
                             <button 
-                                onClick={props.recoverySettings.regenerate}
+                                onClick={() => {
+                                    props.recoverySettings.regenerate();
+                                }}
                                 className="px-3 py-1.5 rounded-lg bg-neon-green/10 border border-neon-green/30 text-neon-green text-[10px] font-bold hover:bg-neon-green/20 transition-colors"
                             >
-                                Regenerate
+                                {props.recoverySettings.count === 0 ? 'Generate' : 'Regenerate'}
                             </button>
                         </div>
 
-                        {props.recoverySettings.codes.length > 0 ? (
-                            <div className="grid grid-cols-2 gap-2">
-                                {props.recoverySettings.codes.map((code, idx) => (
-                                    <div key={idx} className="px-2 py-1.5 rounded bg-black/50 text-[10px] font-mono text-zinc-400 text-center border border-zinc-800">
-                                        {code}
-                                    </div>
-                                ))}
-                            </div>
-                        ) : (
-                            <p className="text-[10px] text-zinc-500 text-center py-2">
-                                Press "Regenerate" to create new codes
-                            </p>
-                        )}
+                        <p className="text-[10px] text-zinc-500 text-center py-2">
+                            {props.recoverySettings.count > 0
+                                ? `${props.recoverySettings.count}/10 codes remaining`
+                                : 'No recovery codes generated yet'}
+                        </p>
                     </div>
 
                     <p className="text-[9px] text-zinc-600 leading-relaxed">

--- a/utils/keyWrapping.ts
+++ b/utils/keyWrapping.ts
@@ -1,0 +1,105 @@
+import { argon2id } from 'hash-wasm';
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+export function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export async function deriveKey(
+  secret: string,
+  salt: Uint8Array,
+  params?: { iterations?: number; memorySize?: number; parallelism?: number }
+): Promise<CryptoKey> {
+  const { iterations = 19, memorySize = 131072, parallelism = 4 } = params || {};
+  const hash = await argon2id({
+    password: secret,
+    salt,
+    iterations,
+    memorySize,
+    parallelism,
+    hashLength: 32,
+    outputType: 'binary',
+  }) as Uint8Array;
+
+  return await window.crypto.subtle.importKey(
+    'raw',
+    hash as unknown as BufferSource,
+    { name: 'AES-GCM' },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+export async function wrapRawKey(
+  rawKey: Uint8Array,
+  wrappingKey: CryptoKey
+): Promise<{ ciphertext: string; iv: string }> {
+  const iv = window.crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await window.crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: iv as unknown as BufferSource },
+    wrappingKey,
+    rawKey as unknown as BufferSource
+  );
+  return {
+    ciphertext: bytesToBase64(new Uint8Array(ciphertext)),
+    iv: bytesToBase64(iv),
+  };
+}
+
+export async function unwrapRawKey(
+  wrapper: { ciphertext: string; iv: string },
+  wrappingKey: CryptoKey
+): Promise<Uint8Array> {
+  const ciphertext = base64ToBytes(wrapper.ciphertext);
+  const iv = base64ToBytes(wrapper.iv);
+  const decrypted = await window.crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: iv as unknown as BufferSource },
+    wrappingKey,
+    ciphertext as unknown as BufferSource
+  );
+  return new Uint8Array(decrypted);
+}
+
+export function generateRecoveryCodes(): string[] {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  const codes: string[] = [];
+  for (let i = 0; i < 10; i++) {
+    const idx = String(i + 1).padStart(2, '0');
+    const randomValues = new Uint8Array(12);
+    window.crypto.getRandomValues(randomValues);
+    let body = '';
+    for (let j = 0; j < 12; j++) {
+      body += chars[randomValues[j] % chars.length];
+      if ((j + 1) % 4 === 0 && j !== 11) body += '-';
+    }
+    codes.push(`CRYTO-${idx}-${body}`);
+  }
+  return codes;
+}
+
+export function parseCodeIndex(code: string): string | null {
+  const match = code.match(/^CRYTO-(\d{2})-/);
+  return match ? match[1] : null;
+}
+
+export interface CryptoMetadata {
+  master_salt: string;
+  recovery_salts: string[];
+}
+
+export interface VaultWrappers {
+  master: { ciphertext: string; iv: string };
+  recovery: Record<string, { ciphertext: string; iv: string }>;
+}


### PR DESCRIPTION
## Summary
- **Zero-knowledge recovery codes**: Replaced plaintext/hashed recovery codes with Argon2id + AES-256-GCM key wrapping. Each recovery code independently decrypts the Master Vault Key (MVK) — no stored hash, no plaintext, zero-knowledge against storage access.
- **MVK security fix**: MVK moved from `sessionStorage` (vulnerable to XSS/browser extensions) to a React ref (`mvkBytesRef`) — strictly in-memory, cleared on lock.
- **Password reset without data loss**: Reset re-wraps the same MVK under a new master key. PIN hash, vault contents, and all data survive password changes.
- **New recovery code format**: `CRYTO-XX-XXXX-XXXX-XXXX` with index prefix for O(1) lookup and unambiguous alphabet (no I,O,0,1).
- **Backward compatible**: Detects new wrapper format (`crytotool_vault_wrappers`) first, falls back to legacy `crytotool_salt/iv/vault_blob` for existing people 

## Files changed
| File | Change |
|------|--------|
| `utils/keyWrapping.ts` | **New** — `deriveKey()`, `wrapRawKey()`, `unwrapRawKey()`, `generateRecoveryCodes()` |
| `components/RecoveryCodesModal.tsx` | **New** — modal for displaying/downloading codes |
| `App.tsx` | MVK ref, recovery reset flow, new code generation, sync recovery count |
| `components/AuthScreen.tsx` | Setup generates MVK+wrappers, unlock unwraps from master wrapper, unified recovery form |
| `components/Dashboard.tsx` | Updated recovery props, shows RecoveryCodesModal |
| `components/views/SettingsView.tsx` | Updated recovery display (count instead of full list) |

## Verification
- `npx tsc --noEmit` — clean
- `npm run build` — clean
- Security: zero `sessionStorage` reads/writes of raw MVK remaining in codebase