### PR TITLE
fix: bump react-dom and @types/react-dom to v19 for React 19 compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "libsodium-wrappers": "^0.8.2",
         "lucide-react": "^1.17.0",
         "react": "^19.2.7",
-        "react-dom": "^18.2.0",
+        "react-dom": "^19.2.7",
         "react-icons": "^4.11.0"
       },
       "devDependencies": {
@@ -44,7 +44,7 @@
         "@types/node": "^25.9.2",
         "@types/prop-types": "^15.7.15",
         "@types/react": "^19.2.17",
-        "@types/react-dom": "^18.2.15",
+        "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
         "autoprefixer": "^10.4.16",
         "postcss": "^8.5.15",
@@ -914,11 +914,13 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1402,10 +1404,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "license": "MIT"
-    },
     "node_modules/libsodium": {
       "version": "0.8.4",
       "license": "ISC"
@@ -1689,16 +1687,6 @@
       "version": "1.2.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/lucide-react": {
       "version": "1.17.0",
@@ -2022,14 +2010,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-icons": {
@@ -2144,11 +2133,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "libsodium-wrappers": "^0.8.2",
     "lucide-react": "^1.17.0",
     "react": "^19.2.7",
-    "react-dom": "^18.2.0",
+    "react-dom": "^19.2.7",
     "react-icons": "^4.11.0"
   },
   "devDependencies": {
@@ -46,7 +46,7 @@
     "@types/node": "^25.9.2",
     "@types/prop-types": "^15.7.15",
     "@types/react": "^19.2.17",
-    "@types/react-dom": "^18.2.15",
+    "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.5.15",


### PR DESCRIPTION
## Summary

`react` and `@types/react` were already bumped to v19, but `react-dom` and `@types/react-dom` remained at v18, causing `npm ci` to fail with peer dependency conflicts. This aligns the DOM packages with the React 19 major version.

## Changes

- `react-dom`: `^18.2.0` → `^19.2.7`
- `@types/react-dom`: `^18.2.15` → `^19.2.3`
- `package-lock.json` regenerated

## Checklist

- [x] PR does NOT modify cryptographic code, key derivation, or encryption algorithms
- [x] `npx tsc --noEmit` passed (0 new errors; 8 pre-existing lucide-react v1 type issues)
- [x] `npm ci` passes
- [x] No docs changes needed