### PR TITLE
fix: resolve lucide-react v1 type errors (size prop, missing Github icon)

### DIFF
--- a/components/CustomizeModal.tsx
+++ b/components/CustomizeModal.tsx
@@ -469,14 +469,14 @@ export const CustomizeModal: React.FC<{
                                                     >
                                                         {/* Large Faded Background Icon */}
                                                         <div className="absolute top-0 right-0 p-5 opacity-5 group-hover:opacity-10 transition-opacity pointer-events-none">
-                                                             {React.cloneElement(pack.icon as React.ReactElement, { size: 90 })}
+                                                             {React.cloneElement(pack.icon as React.ReactElement<any>, { size: 90 })}
                                                         </div>
 
                                                         {/* Header Section */}
                                                         <div className="flex items-center gap-4 relative z-10">
                                                             {/* Gradient Icon Box */}
                                                             <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-neon-green to-emerald-600 flex items-center justify-center text-black shadow-lg shrink-0">
-                                                               {React.cloneElement(pack.icon as React.ReactElement, { size: 24 })}
+                                                               {React.cloneElement(pack.icon as React.ReactElement<any>, { size: 24 })}
                                                             </div>
                                                             <div>
                                                                 <h4 className="font-bold text-primary text-lg leading-tight">{pack.name}</h4>

--- a/components/FileActionMenu.tsx
+++ b/components/FileActionMenu.tsx
@@ -48,7 +48,7 @@ export const FileActionMenu: React.FC<FileActionMenuProps> = ({ isOpen, onClose,
           p-1.5 rounded-lg bg-surface/30 
           ${isDanger ? 'text-red-500' : 'text-muted'}
         `}>
-          {React.cloneElement(icon as React.ReactElement, { size: 16 })}
+          {React.cloneElement(icon as React.ReactElement<any>, { size: 16 })}
         </div>
         <span className={`text-[7px] font-bold uppercase tracking-wider ${isDanger ? 'text-red-500' : 'text-primary'}`}>{label}</span>
       </motion.button>
@@ -72,7 +72,7 @@ export const FileActionMenu: React.FC<FileActionMenuProps> = ({ isOpen, onClose,
         `}
       >
         <div className={`p-1.5 rounded-lg bg-surface/30 ${isDanger ? 'text-red-500' : 'text-muted'}`}>
-          {React.cloneElement(icon as React.ReactElement, { size: 16 })}
+          {React.cloneElement(icon as React.ReactElement<any>, { size: 16 })}
         </div>
         <span className={`text-sm font-medium ${isDanger ? 'text-red-500' : 'text-primary'}`}>{label}</span>
       </motion.button>

--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -649,7 +649,7 @@ export const NavButton: React.FC<NavButtonProps> = ({
       w-16 h-8 rounded-xl flex items-center justify-center transition-all duration-300
       ${active ? 'bg-neon-green shadow-[0_0_15px_rgba(var(--accent-rgb),0.4)]' : 'bg-transparent'}
     `}>
-      {React.cloneElement(icon as React.ReactElement, { 
+      {React.cloneElement(icon as React.ReactElement<any>, { 
         size: 20, 
         className: active ? 'text-black' : 'text-muted',
         strokeWidth: active ? 2.5 : 2

--- a/components/views/SettingsView.tsx
+++ b/components/views/SettingsView.tsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { 
   ArrowLeft, Monitor, LayoutGrid, Palette, PaintBucket, Moon, Sun, Shield, Terminal, 
   FileLock2, EyeOff, Heart, CheckCircle, Globe, Languages, KeyRound, Smartphone, Mail, 
-  Fingerprint, Info, Github, MessageSquare, AtSign, ExternalLink, Ghost, Calendar, MapPin, 
+  Fingerprint, Info, CodeXml, MessageSquare, AtSign, ExternalLink, Ghost, Calendar, MapPin, 
   Type, CaseUpper, ShieldAlert, Skull, Power, ShieldCheck, Lock, Check, Key, Sparkles, ChevronRight,
   Target
 } from 'lucide-react';
@@ -1100,7 +1100,7 @@ export const AboutView: React.FC<{
                            <div className="text-[10px] text-zinc-500">{t('multilingualSupport')}</div>
                       </div>
                       <div className="p-4 bg-zinc-900/60 border border-zinc-800/50 rounded-xl hover:border-neon-green/30 transition-colors">
-                          <Github size={20} className="text-neon-green mb-2" />
+                          <CodeXml size={20} className="text-neon-green mb-2" />
                           <div className="text-white font-bold text-xs mb-1">{t('openSourceLabel')}</div>
                            <div className="text-[10px] text-zinc-500">{t('transparentVerifiable')}</div>
                       </div>
@@ -1132,7 +1132,7 @@ export const AboutView: React.FC<{
                           </div>
                       </div>
                       <button className="p-3 rounded-xl bg-zinc-900 border border-zinc-800 text-white hover:text-neon-green hover:border-neon-green transition-all">
-                          <Github size={20} />
+                          <ExternalLink size={20} />
                       </button>
                   </div>
               </section>

--- a/components/views/VaultView.tsx
+++ b/components/views/VaultView.tsx
@@ -221,11 +221,11 @@ export const VaultView: React.FC<VaultViewProps> = ({ onBack }) => {
                                 className="relative group p-4 sm:p-5 rounded-xl sm:rounded-[24px] glass-card hover:border-neon-green/50 transition-all text-left flex flex-col justify-between h-32 sm:h-36 overflow-hidden"
                             >
                                 <div className="absolute top-0 right-0 p-4 opacity-5 group-hover:opacity-10 transition-opacity transform scale-150 origin-top-right">
-                                    {React.cloneElement(CATEGORY_ICONS[cat.icon] as React.ReactElement, { size: 60 })}
+                                    {React.cloneElement(CATEGORY_ICONS[cat.icon] as React.ReactElement<any>, { size: 60 })}
                                 </div>
 
                                 <div className={`w-10 h-10 rounded-xl flex items-center justify-center text-black shadow-lg mb-4`} style={{ backgroundColor: cat.color }}>
-                                    {React.cloneElement(CATEGORY_ICONS[cat.icon] as React.ReactElement, { size: 20 })}
+                                    {React.cloneElement(CATEGORY_ICONS[cat.icon] as React.ReactElement<any>, { size: 20 })}
                                 </div>
 
                                 <div>


### PR DESCRIPTION
## Summary

`lucide-react` v1 removed the `size` prop from icon type definitions and deleted the `Github` icon. This fixes all 8 TypeScript errors blocking CI builds.

## Changes

- Cast icon elements to `React.ReactElement<any>` in 5 files (CustomizeModal, FileActionMenu, ui.tsx, VaultView) — allows passing `size` prop to lucide icons
- Replace `Github` icon with `CodeXml` (open source card) and `ExternalLink` (developer link) in SettingsView — `Github` was removed in lucide-react v1

## Checklist

- [x] PR does NOT modify cryptographic code, key derivation, or encryption algorithms
- [x] `npx tsc --noEmit` passed (0 errors)
- [x] `npm run build` passes
- [x] No docs changes needed