### PR TITLE
fix: pin scorecard-action to v2.4.3 (v2 tag not available)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Why is it needed? -->

**Issue:** <!-- Closes #..., Fixes #... -->

**Type:** Bug fix / New feature / Security fix / Refactor / Docs / CI / Breaking change

**Platform:** Desktop / Mobile / Web / All

---

## Changes

<!-- List key changes: added, modified, fixed, removed. Be concise. -->

-

---

## Protocol-3305 alignment

CrytoTool follows [Protocol-3305](https://github.com/ObscuritySecurity/protocol-3305).  
✓ = compliant, X = violation (blocking).

| Art. | Principle | Status | Notes |
| ---- | --------- | ------ | ----- |
| 0 | Ethical Monetization |  | |
| 1 | Privacy by Design | | |
| 2 | Security by Default |  | |
| 3 | Zero Trust |  | |
| 4 | Zero Knowledge |  | |
| 5 | Zero Personal Data Collection |  | |
| 6 | Zero Activity Logs |  | |
| 7 | Open Source |  | |
| 8 | Zero Non-Essential Permissions |  | |

---

## Checklist

- [ ] **PR does NOT modify cryptographic code, key derivation, or encryption algorithms**
- [ ] Tested on target platform(s)
- [ ] `npx tsc --noEmit` passed 
- [ ] Docs updated 
