### PR TITLE
ci: fix Scorecard Token-Permissions across all workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/tauri-android.yml
+++ b/.github/workflows/tauri-android.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     permissions:

--- a/.github/workflows/tauri-linux.yml
+++ b/.github/workflows/tauri-linux.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish-tauri:
     permissions:

--- a/.github/workflows/tauri-macos.yml
+++ b/.github/workflows/tauri-macos.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish-tauri:
     permissions:

--- a/.github/workflows/tauri-windows.yml
+++ b/.github/workflows/tauri-windows.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish-tauri:
     permissions:


### PR DESCRIPTION
Add permissions: contents: read to top level of codeql.yml, release.yml, tauri-{android,linux,macos,windows}.yml

## Summary

<!-- What does this PR do? Why is it needed? -->

**Issue:** <!-- Closes #..., Fixes #... -->

**Type:** Bug fix / New feature / Security fix / Refactor / Docs / CI / Breaking change

**Platform:** Desktop / Mobile / Web / All

---

## Changes

<!-- List key changes: added, modified, fixed, removed. Be concise. -->

-

---

## Protocol-3305 alignment

CrytoTool follows [Protocol-3305](https://github.com/ObscuritySecurity/protocol-3305).  
✓ = compliant, X = violation (blocking).

| Art. | Principle | Status | Notes |
| ---- | --------- | ------ | ----- |
| 0 | Ethical Monetization |  | |
| 1 | Privacy by Design | | |
| 2 | Security by Default |  | |
| 3 | Zero Trust |  | |
| 4 | Zero Knowledge |  | |
| 5 | Zero Personal Data Collection |  | |
| 6 | Zero Activity Logs |  | |
| 7 | Open Source |  | |
| 8 | Zero Non-Essential Permissions |  | |

---

## Checklist

- [ ] **PR does NOT modify cryptographic code, key derivation, or encryption algorithms**
- [ ] Tested on target platform(s)
- [ ] `npx tsc --noEmit` passed 
- [ ] Docs updated 
