### PR TITLE
fix: correct YAML indentation in tauri-linux.yml (Scorecard parsing)

### DIFF
--- a/.github/workflows/tauri-linux.yml
+++ b/.github/workflows/tauri-linux.yml
@@ -10,9 +10,9 @@ permissions:
   contents: read
 
 jobs:
-   publish-tauri:
-     permissions:
-       contents: write
+  publish-tauri:
+    permissions:
+      contents: write
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
## Summary

**Issue:** Scorecard scan fails on 5 checks (Dangerous-Workflow, Packaging, Token-Permissions, Pinned-Dependencies, SAST) due to invalid YAML in tauri-linux.yml
**Type:** Bug fix
**Platform:** Linux

## Changes

- Fixed indentation of `publish-tauri` job from 3 spaces to 2 (matching project convention)
- All 10 workflow YAML files now parse correctly

## Protocol-3305 Alignment

| Art. | Principle | Status | Notes |
| --- | --- | --- | --- |
| 0 | Ethical Monetization | ✓ | No monetization change |
| 1 | Privacy by Design | ✓ | No crypto changes |
| 2 | Security by Default | ✓ | Fixes Scorecard scan (security posture monitoring) |
| 3 | Zero Trust | ✓ | No new trust relationships |
| 4 | Zero Knowledge | ✓ | Untouched |
| 5 | Zero Personal Data Collection | ✓ | Untouched |
| 6 | Zero Activity Logs | ✓ | Untouched |
| 7 | Open Source | ✓ | Pipeline fix, fully auditable |
| 8 | Zero Non-Essential Permissions | ✓ | No permission changes |

## Checklist

- [x] PR does NOT modify cryptographic code, key derivation, or encryption algorithms
- [x] Validated: all 10 workflow YAML files parse correctly
- [x] npx tsc --noEmit passed