### PR TITLE
fix: Scorecard Token-Permissions + Pinned-Dependencies alerts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   npm:

--- a/.github/workflows/tauri-linux.yml
+++ b/.github/workflows/tauri-linux.yml
@@ -10,9 +10,9 @@ permissions:
   contents: read
 
 jobs:
-   publish-tauri:
-     permissions:
-       contents: write
+  publish-tauri:
+    permissions:
+      contents: write
     runs-on: ubuntu-24.04
 
     steps:
@@ -91,7 +91,7 @@ jobs:
         run: |
           cd /tmp
           wget -q https://github.com/probonopd/go-appimage/releases/download/continuous/appimagetool-940-x86_64.AppImage
-           echo "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5  appimagetool-940-x86_64.AppImage" | sha256sum --check
+          echo "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5  appimagetool-940-x86_64.AppImage" | sha256sum --check
           chmod +x appimagetool-940-x86_64.AppImage
           ./appimagetool-940-x86_64.AppImage --appimage-extract > /dev/null
           ls -la squashfs-root/usr/bin/appimagetool


### PR DESCRIPTION
## Summary

**Issue:** Code Scanning alerts from Scorecard
**Type:** Bug fix
**Platform:** All

## Changes

- `publish.yml`: removed `packages: write` from workflow-level permissions (leaves only at job level) — fixes Token-Permissions alerts #136, #135
- `tauri-linux.yml`: fixed inconsistent leading whitespace in appimagetool SHA256 verification — fixes Pinned-Dependencies alert #112

## Protocol-3305 Alignment

| Art. | Principle | Status | Notes |
| --- | --- | --- | --- |
| 0 | Ethical Monetization | ✓ | No monetization change |
| 1 | Privacy by Design | ✓ | No crypto changes |
| 2 | Security by Default | ✓ | Fixes Scorecard Code Scanning alerts |
| 3 | Zero Trust | ✓ | No new trust relationships |
| 4 | Zero Knowledge | ✓ | Untouched |
| 5 | Zero Personal Data Collection | ✓ | Untouched |
| 6 | Zero Activity Logs | ✓ | Untouched |
| 7 | Open Source | ✓ | Pipeline fix, fully auditable |
| 8 | Zero Non-Essential Permissions | ✓ | Removes excessive `packages: write` at workflow level |

## Checklist

- [x] PR does NOT modify cryptographic code, key derivation, or encryption algorithms
- [x] Validated: all workflow YAML files parse correctly
- [x] npx tsc --noEmit passed