### PR TITLE
fix(android): exclude tauri-plugin-keyring on android target

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,8 +16,10 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tauri-plugin-keyring = "0.1.0"
 crypto-core = { path = "../crypto-core" }
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+tauri-plugin-keyring = "0.1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.21"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,8 +16,12 @@ fn setup_webkit_env() {
 pub fn run() {
     setup_webkit_env();
 
-    tauri::Builder::default()
-        .plugin(tauri_plugin_keyring::init())
+    let builder = tauri::Builder::default();
+
+    #[cfg(not(target_os = "android"))]
+    let builder = builder.plugin(tauri_plugin_keyring::init());
+
+    builder
         .invoke_handler(tauri::generate_handler![
             greet,
             biometric_android::check_biometric_available,


### PR DESCRIPTION
## Summary

- **Issue:** Android APK build fails because `tauri-plugin-keyring` (v0.1.0) does not compile on Android targets
- **Type:** Bug fix
- **Platform:** Mobile (Android)

## Changes

- Moved `tauri-plugin-keyring` to `[target.'cfg(not(target_os = "android"))'.dependencies]` in `Cargo.toml`
- Added `#[cfg(not(target_os = "android"))]` guard around keyring plugin initialization in `lib.rs`

## Protocol-3305 alignment

| Art. | Principle | Status | Notes |
|------|-----------|--------|-------|
| 0 | Ethical Monetization | ✓ | No monetization change |
| 1 | Privacy by Design | ✓ | No design change |
| 2 | Security by Default | ✓ | No security change |
| 3 | Zero Trust | ✓ | No trust model change |
| 4 | Zero Knowledge | ✓ | No crypto change |
| 5 | Zero Personal Data Collection | ✓ | No data handling change |
| 6 | Zero Activity Logs | ✓ | No logging change |
| 7 | Open Source | ✓ | Code remains auditable |
| 8 | Zero Non-Essential Permissions | ✓ | No permission change |

## Checklist

- [x] PR does NOT modify cryptographic code, key derivation, or encryption algorithms
- [ ] Tested on target platform(s)
- [x] npx tsc --noEmit passed
- [ ] Docs updated