### PR TITLE
fix(i18n): elimina 'Geometric' din descrierea pachetului Material icons

### DIFF
--- a/locales/en.ts
+++ b/locales/en.ts
@@ -403,7 +403,7 @@ export const translations: Translations = {
   packFontAwesome: 'FontAwesome',
   packFontAwesomeDesc: 'Classic, Robust',
   packMaterial: 'Material',
-  packMaterialDesc: 'Google, Geometric',
+  packMaterialDesc: 'Google Material',
   packBootstrap: 'Bootstrap',
   packBootstrapDesc: 'Web, Simple',
   packBoxIcons: 'BoxIcons',

--- a/locales/es.ts
+++ b/locales/es.ts
@@ -404,7 +404,7 @@ export const translations: Translations = {
   packFontAwesome: 'FontAwesome',
   packFontAwesomeDesc: 'Clásico, Robusto',
   packMaterial: 'Material',
-  packMaterialDesc: 'Google, Geométrico',
+  packMaterialDesc: 'Google Material',
   packBootstrap: 'Bootstrap',
   packBootstrapDesc: 'Web, Simple',
   packBoxIcons: 'BoxIcons',

--- a/locales/ro.ts
+++ b/locales/ro.ts
@@ -404,7 +404,7 @@ export const translations: Translations = {
   packFontAwesome: 'FontAwesome',
   packFontAwesomeDesc: 'Clasic, Robust',
   packMaterial: 'Material',
-  packMaterialDesc: 'Google, Geometric',
+  packMaterialDesc: 'Google Material',
   packBootstrap: 'Bootstrap',
   packBootstrapDesc: 'Web, Simplu',
   packBoxIcons: 'BoxIcons',


### PR DESCRIPTION
## Summary

Eliminat cuvantul 'Geometric'/'Geométrico' din descrierea pachetului de iconite Material () in toate cele 3 limbi prioritare.

- `en.ts`: `'Google, Geometric'` → `'Google Material'`
- `ro.ts`: `'Google, Geometric'` → `'Google Material'`
- `es.ts`: `'Google, Geométrico'` → `'Google Material'`

Celelalte 48 de limbi folosesc fallback-ul din engleza si se vor actualiza automat.